### PR TITLE
Terminal selection matches editor style. Fixes #2

### DIFF
--- a/themes/minuit-color-theme.json
+++ b/themes/minuit-color-theme.json
@@ -287,7 +287,7 @@
         "terminal.background": "#151328",
         "terminal.border": "#070e1b",
         "terminal.foreground": "#d6d9e0",
-        "terminal.selectionBackground": "#15132880",
+        "terminal.selectionBackground": "#3d3961b3",
         "terminalCursor.background": "#332d0f",
         "terminalCursor.foreground": "#7785ac",
         "textBlockQuote.background": "#151328",


### PR DESCRIPTION
Existing disparity between `terminal.foreground` and `terminal.selectionBackground` simply isn't visible to the naked eye. This change makes `terminal.selectionBackground` match `editor.selectionBackground`